### PR TITLE
Setting default btn border width

### DIFF
--- a/src/components/button/styles.scss
+++ b/src/components/button/styles.scss
@@ -3,6 +3,9 @@
 @import "~bootstrap/scss/mixins";
 @import "~bootstrap/scss/buttons";
 
+// This is undefined otherwise
+$btn-border-width: default;
+
 //
 // Base styles
 //


### PR DESCRIPTION
ERROR in ./node_modules/css-loader?{"importLoaders":3}!./node_modules/postcss-loader/lib?{"config":{"path":"/Users/richardsumilang/Projects/github/triniti/admin-ui-plugin-js/demo/postcss.config.js"}}!./node_modules/sass-loader/lib/loader.js!./node_modules/sass-resources-loader/lib/loader.js?{"resources":"/Users/richardsumilang/Projects/github/triniti/admin-ui-plugin-js/demo/src/assets/styles/_variables.scss"}!../src/components/button/styles.scss
Module build failed: 
undefined
         ^
      Undefined variable: "$btn-border-width".
      in /Users/richardsumilang/Projects/github/triniti/admin-ui-plugin-js/src/components/button/styles.scss (line 581, column 11)
 @ ../src/components/button/styles.scss 2:14-288 21:1-42:3 22:19-293
 @ ../src/components/button/index.jsx
 @ ../src/components/screen/index.jsx
 @ ../src/components/index.js
 @ ./src/screens/alert-bars/index.jsx
 @ ./src/screens lazy ^\.\/.*$
 @ ./src/routes.js
 @ ./src/index.jsx
 @ multi (webpack)-dev-server/client?https://localhost:8080 webpack/hot/dev-server react-hot-loader/patch webpack-dev-server/client?https://localhost:8080 ./index.jsx
webpack: Failed to compile.
