### PR TITLE
RE #73: Form Updates and a few new Props in UI Pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.4.6
+* Form updates and a few new props in UI pages.
+
+
 ## v0.4.5
 * issue #72: Adding Props, Icons, CheckBox fix, Card & CardHeader fixes.
 

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -10323,9 +10323,9 @@
       }
     },
     "url-loader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.0.0.tgz",
-      "integrity": "sha512-7Xo5gquuyxreeo9AGwzzjdkwgmRvKvusb2ZGBxV2HbrWCSJRF+IwKrdQXlMni2hMFyot12KyytNQ76nSYMu/nQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.0.1.tgz",
+      "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
@@ -10334,9 +10334,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.0.tgz",
-          "integrity": "sha1-r6wpW7qgFSRJ5SJ0LkVHwa6TKNI=",
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
+          "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
           "dev": true,
           "requires": {
             "fast-deep-equal": "1.0.0",
@@ -10356,7 +10356,7 @@
           "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
           "dev": true,
           "requires": {
-            "ajv": "6.2.0",
+            "ajv": "6.2.1",
             "ajv-keywords": "3.1.0"
           }
         }

--- a/demo/package.json
+++ b/demo/package.json
@@ -56,7 +56,7 @@
     "sass-resources-loader": "^1.3.3",
     "style-loader": "^0.20.2",
     "svg-fill-loader": "^0.0.8",
-    "url-loader": "^1.0.0",
+    "url-loader": "^1.0.1",
     "webpack": "^3.11.0",
     "webpack-bundle-analyzer": "^2.11.1",
     "webpack-dev-server": "^2.11.2"

--- a/demo/src/screens/alerts/index.jsx
+++ b/demo/src/screens/alerts/index.jsx
@@ -133,10 +133,10 @@ class UiAlert extends Component {
               <Button radius="circle" color="hover-bg" onClick={this.toggleCode1} active={this.state.collapseCode1}>
                 <Icon imgSrc="code" size="md"/>
               </Button>
-              </CardHeader>
-              <Collapse isOpen={this.state.collapseCode1}>
-                  <CardBody className="pl-5 bg-light">
-                  <pre>
+            </CardHeader>
+            <Collapse isOpen={this.state.collapseCode1}>
+              <CardBody className="pl-5 bg-light">
+<pre>
 <code>{`import React from 'react';
 import { Alert, UncontrolledAlert } from '@triniti/admin-ui-plugin/components';
 
@@ -161,8 +161,8 @@ const Example = (props) => {
     </div>
   );
 };`}</code></pre>
-                  </CardBody>
-                </Collapse>
+              </CardBody>
+            </Collapse>
             <CardBody>
               <Alert color="success" inverse>
                 <strong>Well done!</strong> You successfully read this important alert message.
@@ -280,8 +280,11 @@ const Example = (props) => {
                 </tbody>
               </Table>
               <br />
-              <Alert color="info">
-                <span className="ion-android-alert float-left" />
+              <Alert color="info" className="text-left">
+                <h3 className="alert-heading" className="mb-1">
+                  <Icon imgSrc="warning-outline-alt" className="mr-2" size="lg"/>
+                  Example Alert Heading with Icon
+                </h3>
                 <strong>The complete list of common words:</strong><br />
               a, an, and, are, as, at, be, but, by, for, if, in, into, is, it,
               no, not, of, on, or, such, that, the, their, then, there, these,

--- a/demo/src/screens/breadcrumbs/index.jsx
+++ b/demo/src/screens/breadcrumbs/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PrimaryActions from '../../components/primary-actions';
 import Sidenav from '../../components/sidenav';
 import {
@@ -9,58 +9,177 @@ import {
   CardBody,
   CardHeader,
   CardTitle,
+  Collapse,
   Icon,
   Screen,
+  Table,
 } from '../../../../src/components';
 
-const UiBreadcrumb = () => (
-  <Screen
-    sidenav={<Sidenav activeScreen="breadcrumbs" />}
-    sidenavHeader
-    header="Breadcrumbs"
-    breadcrumbs={[
-      { to: '/', text: 'Demos' },
-      { text: 'Breadcrumbs' },
-    ]}
-    // tabs={[
-    //   { to: '/welcome', text: 'Tab1' },
-    //   { to: '#/test2', text: 'Tab2' },
-    // ]}
-    primaryActions={<PrimaryActions />}
-    body={
-      <Card>
-        <CardHeader>
-          <Breadcrumb>
-            <BreadcrumbItem><a href="#">Home</a></BreadcrumbItem>
-            <BreadcrumbItem><a href="#">Library</a></BreadcrumbItem>
-            <BreadcrumbItem active>Data</BreadcrumbItem>
-          </Breadcrumb>
-          <Button outline color="link" radius="circle">
-            <Icon imgSrc="close-sm"/>
-          </Button>
-        </CardHeader>
-        <CardBody>
-          <Breadcrumb>
-            <BreadcrumbItem><a href="#">Home</a></BreadcrumbItem>
-            <BreadcrumbItem><a href="#">Library</a></BreadcrumbItem>
-            <BreadcrumbItem active>Data</BreadcrumbItem>
-          </Breadcrumb>
-          <br />
-          <br />
-          <br />
-          <CardTitle tag="h4">No List Markup</CardTitle>
-          <div className="breadcrumbs pl-0">
-            <Breadcrumb tag="nav">
-              <BreadcrumbItem tag="a" href="#">Home</BreadcrumbItem>
-              <BreadcrumbItem tag="a" href="#">Library</BreadcrumbItem>
-              <BreadcrumbItem tag="a" href="#">Data</BreadcrumbItem>
-              <BreadcrumbItem active tag="span">Bootstrap</BreadcrumbItem>
-            </Breadcrumb>
-          </div>
-        </CardBody>
-      </Card>
-    }
-  />
-);
+class UiBreadcrumb extends Component {
+  constructor(props) {
+    super(props);
+    this.toggleCode1 = this.toggleCode1.bind(this);
+    this.toggleCode2 = this.toggleCode2.bind(this);
+    this.state = {
+      collapseCode1: false,
+      collapseCode2: false
+    };
+  }
+
+  toggleCode1() {
+    this.setState({ collapseCode1: !this.state.collapseCode1 });
+  }
+
+  toggleCode2() {
+    this.setState({ collapseCode2: !this.state.collapseCode2 });
+  }
+
+
+  render() {
+    return (
+      <Screen
+        sidenav={<Sidenav activeScreen="breadcrumbs" />}
+        sidenavHeader
+        header="Breadcrumbs"
+        breadcrumbs={[
+          { to: '/', text: 'Demos' },
+          { text: 'Breadcrumbs' },
+        ]}
+        // tabs={[
+        //   { to: '/welcome', text: 'Tab1' },
+        //   { to: '#/test2', text: 'Tab2' },
+        // ]}
+        primaryActions={<PrimaryActions />}
+        body={[
+          <Card key="props1">
+            <CardHeader>Breadcrumb Properties</CardHeader>
+            <CardBody>
+              <Table hover responsive>
+                <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                  <th scope="row">tag</th>
+                  <td>bool</td>
+                  <td>'ol'</td>
+                  <td>For "No List Markup" tag="nav".</td>
+                </tr>
+                </tbody>
+              </Table>
+            </CardBody>
+          </Card>,
+
+          <Card key="props2">
+            <CardHeader>BreadcrumbItem Properties</CardHeader>
+            <CardBody>
+              <Table hover responsive>
+                <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Type</th>
+                  <th>Default</th>
+                  <th>Description</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                  <th scope="row">tag</th>
+                  <td>bool</td>
+                  <td>'li'</td>
+                  <td>For "No List Markup" tag="a" and include href inside component tag.</td>
+                </tr>
+                <tr>
+                  <th scope="row">active</th>
+                  <td>bool</td>
+                  <td></td>
+                  <td>Adds "active" class to show active item. For "No List Markup" tag="span".</td>
+                </tr>
+                </tbody>
+              </Table>
+            </CardBody>
+          </Card>,
+
+          <Card key="breadcrumbs1">
+            <CardHeader>
+              <Breadcrumb>
+                <BreadcrumbItem><a href="#">Home</a></BreadcrumbItem>
+                <BreadcrumbItem><a href="#">Library</a></BreadcrumbItem>
+                <BreadcrumbItem active>Data</BreadcrumbItem>
+              </Breadcrumb>
+              <Button radius="circle" color="hover-bg" onClick={this.toggleCode1} active={this.state.collapseCode1}>
+                <Icon imgSrc="code" size="md"/>
+              </Button>
+            </CardHeader>
+            <Collapse isOpen={this.state.collapseCode1}>
+              <CardBody className="pl-5 bg-light">
+<pre>
+<code>{`import React from 'react';
+import { Breadcrumb, BreadcrumbItem } from '@triniti/admin-ui-plugin/components';
+
+const Example = (props) => {
+  return (
+    <Breadcrumb>
+      <BreadcrumbItem><a href="#">Home</a></BreadcrumbItem>
+      <BreadcrumbItem><a href="#">Library</a></BreadcrumbItem>
+      <BreadcrumbItem active>Data</BreadcrumbItem>
+    </Breadcrumb>
+  );
+};`}</code></pre>
+              </CardBody>
+            </Collapse>
+            <CardBody>
+              <Breadcrumb>
+                <BreadcrumbItem><a href="#">Home</a></BreadcrumbItem>
+                <BreadcrumbItem><a href="#">Library</a></BreadcrumbItem>
+                <BreadcrumbItem active>Data</BreadcrumbItem>
+              </Breadcrumb>
+            </CardBody>
+          </Card>,
+
+          <Card key="breadcrumbs2">
+            <CardHeader>
+              No List Markup
+              <Button radius="circle" color="hover-bg" onClick={this.toggleCode2} active={this.state.collapseCode2}>
+                <Icon imgSrc="code" size="md"/>
+              </Button>
+            </CardHeader>
+            <Collapse isOpen={this.state.collapseCode2}>
+              <CardBody className="pl-5 bg-light">
+<pre>
+<code>{`import React from 'react';
+import { Breadcrumb, BreadcrumbItem } from '@triniti/admin-ui-plugin/components';
+
+const Example = (props) => {
+  return (
+    <Breadcrumb tag="nav">
+      <BreadcrumbItem tag="a" href="#">Home</BreadcrumbItem>
+      <BreadcrumbItem tag="a" href="#">Library</BreadcrumbItem>
+      <BreadcrumbItem tag="a" href="#">Data</BreadcrumbItem>
+      <BreadcrumbItem active tag="span">Bootstrap</BreadcrumbItem>
+    </Breadcrumb>
+  );
+};`}</code></pre>
+              </CardBody>
+            </Collapse>
+            <CardBody>
+              <Breadcrumb tag="nav">
+                <BreadcrumbItem tag="a" href="#">Home</BreadcrumbItem>
+                <BreadcrumbItem tag="a" href="#">Library</BreadcrumbItem>
+                <BreadcrumbItem tag="a" href="#">Data</BreadcrumbItem>
+                <BreadcrumbItem active tag="span">Bootstrap</BreadcrumbItem>
+              </Breadcrumb>
+            </CardBody>
+          </Card>,
+        ]}
+      />
+    );
+  }
+}
 
 export default UiBreadcrumb;

--- a/demo/src/screens/button-dropdowns/index.jsx
+++ b/demo/src/screens/button-dropdowns/index.jsx
@@ -1,30 +1,38 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PrimaryActions from '../../components/primary-actions';
 import Sidenav from '../../components/sidenav';
-import { ButtonDropdown, Card, CardBody, DropdownItem, DropdownMenu, DropdownToggle, Icon, Screen } from '../../../../src/components';
+import { Button, ButtonDropdown, Card, CardBody, CardHeader, Collapse, DropdownItem, Dropdown, DropdownMenu, DropdownToggle, Icon, Screen, Table } from '../../../../src/components';
 
-class UiButtonDropdown extends React.Component {
+class UiButtonDropdown extends Component {
   constructor(props) {
     super(props);
 
-    this.toggle = this.toggle.bind(this);
+    this.toggle1 = this.toggle1.bind(this);
     this.toggle2 = this.toggle2.bind(this);
+    this.toggleCode1 = this.toggleCode1.bind(this);
+    this.toggleCode2 = this.toggleCode2.bind(this);
     this.state = {
       dropdownOpen: false,
       dropdownOpen2: false,
+      collapseCode1: false,
+      collapseCode2: false
     };
   }
 
-  toggle() {
-    this.setState({
-      dropdownOpen: !this.state.dropdownOpen,
-    });
+  toggle1() {
+    this.setState({ dropdownOpen1: !this.state.dropdownOpen1 });
   }
 
   toggle2() {
-    this.setState({
-      dropdownOpen2: !this.state.dropdownOpen2,
-    });
+    this.setState({ dropdownOpen2: !this.state.dropdownOpen2 });
+  }
+
+  toggleCode1() {
+    this.setState({ collapseCode1: !this.state.collapseCode1 });
+  }
+
+  toggleCode2() {
+    this.setState({ collapseCode2: !this.state.collapseCode2 });
   }
 
   render() {
@@ -38,12 +46,97 @@ class UiButtonDropdown extends React.Component {
       //   { to: '#/test2', text: 'Tab2' },
       // ]}
         primaryActions={<PrimaryActions />}
-        body={
-          <Card>
+        body={[
+          <Card key="props1">
+            <CardHeader>ButtonDropdown Properties</CardHeader>
+            <CardBody className="pl-5">
+              Same as "Dropdown" component except wraps component in .btn-group class
+            </CardBody>
+          </Card>,
+
+          <Card key="props2">
+            <CardHeader>DropdownToggle Properties</CardHeader>
+            <CardBody>
+              <Table hover responsive>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Default</th>
+                    <th>Description</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <th scope="row">'aria-haspopup'</th>
+                    <td>bool</td>
+                    <td>true</td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <th scope="row">caret</th>
+                    <td>bool</td>
+                    <td></td>
+                    <td>Adds caret icon</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">color</th>
+                    <td>string</td>
+                    <td>light</td>
+                    <td>Sets button color.  Can use all button props including "outline", "hover", "hover-bg", etc</td>
+                  </tr>
+                  <tr>
+                    <th scope="row">disabled</th>
+                    <td>bool</td>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <th scope="row">nav</th>
+                    <td>bool</td>
+                    <td></td>
+                    <td>Adds class .nav-link and sets tag to "a".  Will remove any button styles.</td>
+                  </tr>
+                </tbody>
+              </Table>
+            </CardBody>
+          </Card>,
+
+          <Card key="buttondropdown1">
+            <CardHeader>
+              ButtonDropdown
+              <Button radius="circle" color="hover-bg" onClick={this.toggleCode1} active={this.state.collapseCode1}>
+                <Icon imgSrc="code" size="md"/>
+              </Button>
+            </CardHeader>
+            <Collapse isOpen={this.state.collapseCode1}>
+              <CardBody className="pl-5 bg-light">
+<pre>
+<code>{`import React from 'react';
+import { Breadcrumb, BreadcrumbItem } from '@triniti/admin-ui-plugin/components';
+
+const Example = (props) => {
+  return (
+    <ButtonDropdown isOpen={this.state.dropdownOpen1} toggle={this.toggle1} className="mb-4">
+      <DropdownToggle caret outline color="light" >
+        Button Dropdown
+      </DropdownToggle>
+      <DropdownMenu>
+        <DropdownItem header>Header</DropdownItem>
+        <DropdownItem disabled>Action</DropdownItem>
+        <DropdownItem>Another Action</DropdownItem>
+        <DropdownItem divider />
+        <DropdownItem>Another Action</DropdownItem>
+      </DropdownMenu>
+    </ButtonDropdown>
+  );
+};`}</code></pre>
+              </CardBody>
+            </Collapse>
             <CardBody indent>
-              <ButtonDropdown isOpen={this.state.dropdownOpen} toggle={this.toggle} className="mb-4">
+              <ButtonDropdown isOpen={this.state.dropdownOpen1} toggle={this.toggle1} className="mb-4">
                 <DropdownToggle caret outline color="light">
-            Button Dropdown
+                  Button Dropdown
                 </DropdownToggle>
                 <DropdownMenu>
                   <DropdownItem header>Header</DropdownItem>
@@ -53,12 +146,46 @@ class UiButtonDropdown extends React.Component {
                   <DropdownItem>Another Action</DropdownItem>
                 </DropdownMenu>
               </ButtonDropdown>
+            </CardBody>
+          </Card>,
 
-              <ButtonDropdown isOpen={this.state.dropdownOpen2} toggle={this.toggle2} className="mb-4 ml-4">
+          <Card key="buttondropdown2">
+            <CardHeader>
+              ButtonDropdown with Icon & Arrows
+              <Button radius="circle" color="hover-bg" onClick={this.toggleCode2} active={this.state.collapseCode2}>
+                <Icon imgSrc="code" size="md"/>
+              </Button>
+            </CardHeader>
+            <Collapse isOpen={this.state.collapseCode2}>
+              <CardBody className="pl-5 bg-light">
+<pre>
+<code>{`import React from 'react';
+import { Breadcrumb, BreadcrumbItem } from '@triniti/admin-ui-plugin/components';
+
+const Example = (props) => {
+  return (
+    <ButtonDropdown isOpen={this.state.dropdownOpen2} toggle={this.toggle2}>
+      <DropdownToggle outline radius="circle" color="hover">
+        <Icon imgSrc="more-vertical" alt="more" size="md" />
+      </DropdownToggle>
+      <DropdownMenu left arrow="left">
+        <DropdownItem header>Header</DropdownItem>
+        <DropdownItem disabled>Action</DropdownItem>
+        <DropdownItem>Another Action</DropdownItem>
+        <DropdownItem divider />
+        <DropdownItem>Another Action</DropdownItem>
+      </DropdownMenu>
+    </ButtonDropdown>
+  );
+};`}</code></pre>
+              </CardBody>
+            </Collapse>
+            <CardBody indent>
+              <ButtonDropdown isOpen={this.state.dropdownOpen2} toggle={this.toggle2}>
                 <DropdownToggle outline radius="circle" color="hover">
-                    <Icon imgSrc="more-vertical" alt="more" size="md" />
+                  <Icon imgSrc="more-vertical" alt="more" size="md" />
                 </DropdownToggle>
-                <DropdownMenu right arrow="right">
+                <DropdownMenu left arrow="left">
                   <DropdownItem header>Header</DropdownItem>
                   <DropdownItem disabled>Action</DropdownItem>
                   <DropdownItem>Another Action</DropdownItem>
@@ -67,8 +194,8 @@ class UiButtonDropdown extends React.Component {
                 </DropdownMenu>
               </ButtonDropdown>
             </CardBody>
-          </Card>
-      }
+          </Card>,
+        ]}
       />
     );
   }

--- a/demo/src/screens/forms/index.jsx
+++ b/demo/src/screens/forms/index.jsx
@@ -436,6 +436,12 @@ class UiForm extends React.Component {
                     </Col>
                     </FormGroup>
                     <FormGroup row>
+                      <Label for="exampleSelectMulti" sm={2}>Readonly</Label>
+                      <Col sm={10}>
+                      <Input readonly="readonly" type="textarea" name="text" id="readonlyText3" rows="5">Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</Input>
+                    </Col>
+                    </FormGroup>
+                    <FormGroup row>
                       <Label for="exampleText" sm={2}>Text Area</Label>
                       <Col sm={10}>
                       <Input type="textarea" name="text" id="exampleText3" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/admin-ui-plugin",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6026,9 +6026,9 @@
       }
     },
     "sweetalert2": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-7.13.1.tgz",
-      "integrity": "sha512-aGHAVEmVOUIkmsA2I3/VbGo14v3npkkJIH5Neu1Amxyx+2NPQa8h6F60zDy5dwQCaNDb68WbR2e50Y+O6jRnlQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-7.15.0.tgz",
+      "integrity": "sha512-o+UX/Pu/z1jANSXO+MJgzv9IkQFaxn3KCuy2Tp39O5w/PIggU/nnPbYj5ilx7G77e+SW3THMs8E2dLW+KjPWJw==",
       "dev": true
     },
     "symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/admin-ui-plugin",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "The admin-ui is a javaScript plugin for Triniti apps.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "redux": "^3.7.2",
     "sinon": "^4.4.2",
     "svg-fill-loader": "^0.0.8",
-    "sweetalert2": "^7.13.1",
+    "sweetalert2": "^7.15.0",
     "tape": "^4.9.0"
   },
   "babel": {

--- a/src/components/alert/styles.scss
+++ b/src/components/alert/styles.scss
@@ -11,6 +11,8 @@
   border: none;
   border-radius: 0;
   font-size: .875rem;
+  box-shadow: inset 0 -1px 0 rgba(0,0,0,0.05);
+  text-align: center;
 
   .card-body > & {
     @include border-radius($alert-border-radius);
@@ -35,6 +37,13 @@
   .alert-wrapper & {
     animation: 300ms ease-out 0s 1 slideInAlert;
   }
+}
+
+td.alert,
+th.alert,
+.alert th,
+.alert td {
+  text-align: left;
 }
 
 .alert-wrapper {
@@ -103,11 +112,16 @@
   z-index: $zindex-sticky;
 
   display: flex;
-  min-height: $header-height + 2;
+  // min-height: $header-height + 2;
   align-items: center;
   flex: 0 0 auto;
   justify-content: space-between;
   box-shadow: inset 0 -1px 0 $gray-rgba-300;
+
+  & > span {
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
 
 // Alerts in tables

--- a/src/components/app/_borders.scss
+++ b/src/components/app/_borders.scss
@@ -15,7 +15,7 @@
   width: 4px;
   content: '';
   border-radius: 4px;
-  background-color: $gray-700;
+  background-color: $gray-500;
 }
 
 .col.has-border::before {

--- a/src/components/card/styles.scss
+++ b/src/components/card/styles.scss
@@ -60,7 +60,7 @@
 .card-body-indent {
 
   @media (min-width: 768px) {
-    padding: 3rem;
+    padding: 2.5rem 3rem 3rem 3rem;
   }
 }
 

--- a/src/components/checkbox/styles.scss
+++ b/src/components/checkbox/styles.scss
@@ -128,7 +128,8 @@ input.checkbox-input {
 
 // disabled
 
-.checkbox-input:disabled + label {
+.checkbox-input:disabled + label,
+.checkbox-input[readonly] + label {
   opacity: .5;
   pointer-events: none;
 

--- a/src/components/dropdown-toggle/index.jsx
+++ b/src/components/dropdown-toggle/index.jsx
@@ -6,17 +6,17 @@ import { mapToCssModules } from '../utils';
 import Button from '../button';
 
 const propTypes = {
+  'aria-haspopup': PropTypes.bool,
   caret: PropTypes.bool,
-  color: PropTypes.string,
   children: PropTypes.node,
   className: PropTypes.string,
+  color: PropTypes.string,
   cssModule: PropTypes.object,
   disabled: PropTypes.bool,
+  nav: PropTypes.bool,
   onClick: PropTypes.func,
-  'aria-haspopup': PropTypes.bool,
   split: PropTypes.bool,
   tag: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  nav: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/components/form/styles.scss
+++ b/src/components/form/styles.scss
@@ -23,6 +23,18 @@
     color: $body-color;
     background-color: $white !important;
   }
+
+  .input-group-prepend & {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  .input-group-append & {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  .input-group-prepend:hover & {
+    z-index: 1;
+  }
 }
 
 .form-control-sm {
@@ -92,6 +104,34 @@ select:not([multiple]).form-control-lg {
 
 label {
   margin-bottom: .25rem;
+}
+
+label {
+  font-size: .9em;
+  text-transform: uppercase;
+  letter-spacing: .01em;
+  font-weight: 500;
+  color: #7a7a7a;
+}
+
+.col-form-label {
+  font-size: .9em;
+}
+
+.radio-input-label,
+.switch-input-label,
+.checkbox-input-label,
+.form-check-inline > label {
+  font-size: $font-size-base;
+  text-transform: none;
+  opacity: 1;
+  letter-spacing: 0;
+  font-weight: 400;
+  color: $body-color;
+}
+
+.form-check-inline.disabled > label {
+  opacity: .5;
 }
 
 
@@ -203,9 +243,14 @@ input[type="checkbox"] {
 
 // stacked form-inline
 
-.form-inline + .form-inline {
-  margin-top: .75rem;
+.form-check-inline {
+  margin-bottom: 1rem;
+
+  &:last-child {
+    margin-bottom: $form-group-margin-bottom;
+  }
 }
+
 
 .form-inline .form-group {
   margin-right: $form-item-spacing;
@@ -228,6 +273,39 @@ input[type="checkbox"] {
 .form-check.disabled,
 .form-check.disabled .form-check-label {
   cursor: not-allowed;
+}
+
+// readonly form-control
+
+.form-control[readonly] {
+  border: none;
+  border-top: 1px solid #e9e9e9 !important;
+  padding-left: 0;
+  padding-right: 0;
+  background-color: transparent;
+  background-image: none !important;
+  font-size: .9rem;
+  color: #292929;
+  opacity: 1 !important;
+  box-shadow: none !important;
+
+  &::-webkit-input-placeholder {
+    color: transparent;
+  }
+  &:-moz-placeholder { /* Mozilla Firefox 4 to 18 */
+     color: transparent;
+  }
+  &::-moz-placeholder { /* Mozilla Firefox 19+ */
+     color: transparent;
+  }
+  &:-ms-input-placeholder { /* Internet Explorer 10+ */
+     color: transparent;
+  }
+}
+
+.form-check[readonly],
+.form-check[readonly] .form-check-label {
+  cursor: text;
 }
 
 

--- a/src/components/icon/styles.scss
+++ b/src/components/icon/styles.scss
@@ -16,6 +16,8 @@
   height: 1rem;
   width: 1rem; // 16px
   align-self: center;
+  vertical-align: middle;
+  margin-top: -3px;
 
   .btn & {
     margin-right: .5rem;

--- a/src/components/radio/styles.scss
+++ b/src/components/radio/styles.scss
@@ -91,7 +91,8 @@ input.form-control-lg.radio-input + label {
 
 // disabled
 
-.radio-input:disabled + .radio-input-label {
+.radio-input:disabled + .radio-input-label,
+.radio-input[readonly] + .radio-input-label {
   opacity: .5;
   pointer-events: none;
 

--- a/src/components/table/styles.scss
+++ b/src/components/table/styles.scss
@@ -15,8 +15,8 @@
     font-size: .9em;
     text-transform: uppercase;
     letter-spacing: .01em;
-    font-weight: 400;
-    opacity: .7;
+    font-weight: 500;
+    opacity: .625;
   }
 }
 


### PR DESCRIPTION
- Added initial props to Alerts, Breadcrumbs, button-dropdowns.
- Added [readonly] styles for text inputs
- Centered Alert text, set bottom border on light colored alerts.  Removed min-height on sticky alerts.
- Lighted has-border initial grey
- Decreased top padding of card-body-indent to 2.5rem
- Added readonly to checkbox and radio even though we should only use disabled for these and select boxes
- Alphabetized properties in dropdown-toggle
- Set label font style to match table headers, increased font-weight of table headers to match.
- aligned icons vertically in the middle with negative top margin to fix