### PR TITLE
Mobile Dropdown Toggle

### DIFF
--- a/src/components/main-nav/DropdownUnit.jsx
+++ b/src/components/main-nav/DropdownUnit.jsx
@@ -34,7 +34,14 @@ const DropdownUnit = ({
         tag={NavLink}
         to={to}
         title={title}
-        className="nav-link"
+        className="nav-link nav-link-desktop"
+      >
+        {title}
+      </DropdownToggle>
+      <DropdownToggle
+        onClick={handleToggleClick}
+        className="nav-link nav-link-mobile"
+        nav
       >
         {title}
       </DropdownToggle>

--- a/src/components/main-nav/styles.scss
+++ b/src/components/main-nav/styles.scss
@@ -4,9 +4,20 @@
 
 .main-nav {
   margin-right: auto;
-
+  .nav-link-desktop {
+    display: block;
+  }
+  .nav-link-mobile {
+    display: none;
+  }
   @media (max-width: 1024px) {
     background-color: $navbar-theme-light;
+    .nav-link-desktop {
+      display: none;
+    }
+    .nav-link-mobile {
+      display: block;
+    }
   }
 }
 


### PR DESCRIPTION
Requirement: We want to have the same behaviour as before the update with the "main nav links" on the mobile version. 

Current behaviour:
1. Desktop - when user clicks the main nav link, user will be redirected to whatever assigned href. Needs to use the "NavLink" component to maintain react-router's property.
2. Mobile - should be the same as before. When user clicks the main dropdown link, it'll just open the dropdown.

@mgollnick Feel free to update on what you think is the best. Thank you.
 