### PR TITLE
Create lazy component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 
+## v0.5.14
+* Remove `createLazyCompoent` timeout limit. Use library default value.
+
+
 ## v0.5.13
 * issue #611: Add scroll to top on article tab sections.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@triniti/admin-ui-plugin",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "The admin-ui is a javaScript plugin for Triniti apps.",
   "repository": {
     "type": "git",

--- a/src/components/createLazyComponent.js
+++ b/src/components/createLazyComponent.js
@@ -14,7 +14,6 @@ import Loading from './loading';
 export default (component, options = {}) => {
   const defaults = {
     loading: Loading,
-    timeout: 2500,
     minDelay: 0,
     alwaysDelay: false,
     loadingTransition: true,

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import reducer from './reducers';
 
 export default class AdminUiPlugin extends Plugin {
   constructor() {
-    super('triniti', 'admin-ui', '0.5.13');
+    super('triniti', 'admin-ui', '0.5.14');
   }
 
   configure(app, bottle) {


### PR DESCRIPTION
Remove `createLazyCompoent` timeout limit. Use library default value.